### PR TITLE
Update requirements: add pke and simplify versioning

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -4,5 +4,6 @@ nltk
 spacy
 sentence-transformers
 kaggle
-elasticsearch==7.10.1
-numpy==1.26.4
+elasticsearch
+numpy
+git+https://github.com/boudinfl/pke.git


### PR DESCRIPTION
- Added `pke` library via direct GitHub reference
- Replaced version-specific dependencies:
  - `elasticsearch==7.10.1` → `elasticsearch`
  - `numpy==1.26.4` → `numpy`
- This makes the environment more flexible and easier to maintain

Tested locally in the `ir-project` environment.